### PR TITLE
Aligned trampoline table on 16k pages

### DIFF
--- a/src/aarch64/sysv.S
+++ b/src/aarch64/sysv.S
@@ -356,7 +356,7 @@ CNAME(ffi_closure_SYSV):
 #endif
 
 #if FFI_EXEC_TRAMPOLINE_TABLE
-    .align 12
+    .align 14
 CNAME(ffi_closure_trampoline_table_page):
     .rept 16384 / FFI_TRAMPOLINE_SIZE
     adr	x17, -16384


### PR DESCRIPTION
Initial attempt to quick fix the callback issues observed on AArch64 on iOS. More fixes to PAGE_SIZE might be needed. (Ideally, where possible, getpagesize() should be used at runtime instead.)
